### PR TITLE
Add jetty:run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+## Before you begin
+
+[swagger-springmvc](https://github.com/martypitt/swagger-springmvc) must be installed in your local maven repository.
+
+## Build and Run
+
+```shell
+mvn jetty:run
+```
+
+#### Go to http://localhost:8080/swagger-springmvc-test/index.html
+
+The textfield should be filled with `http://localhost:8080/swagger-springmvc-test/apidoc` 
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,9 @@
 	<groupId>com.mangofactory.swagger</groupId>
 	<artifactId>swagger-springmvc-test</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<packaging>war</packaging>
 	<properties>
-		<spring.version>3.1.0.RELEASE</spring.version>
+		<spring.version>3.1.1.RELEASE</spring.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -86,7 +87,7 @@
 		<dependency>
 			<groupId>com.mangofactory</groupId>
 			<artifactId>swagger-springmvc</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>0.1.6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
@@ -99,4 +100,24 @@
 			<version>1.9.5</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+		<plugin>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>maven-jetty-plugin</artifactId>
+			<version>6.1.26</version>
+			<configuration>
+				<webAppConfig>
+					<contextPath>/swagger-springmvc-test</contextPath>
+				</webAppConfig>
+				<connectors>
+					<connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
+						<port>8080</port>
+						<maxIdleTime>60000</maxIdleTime>
+					</connector>
+				</connectors>
+			</configuration>
+		</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
This is quicker than deploying the war into an external servlet container.
Just type `mvn jetty:run` in project root directory.

Also pick some changes from @rstoyanchev pull request #1, like dependencies
and README.md. Thx Rossen.
