### PR TITLE
Fix to POM file for successful build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.mangofactory</groupId>
 			<artifactId>swagger-springmvc</artifactId>
-			<version>0.1.6-SNAPSHOT</version>
+			<version>0.2.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
See issue #4 on the original project at https://github.com/martypitt/swagger-springmvc-example/issues/4 .

This derivative contains a correct reference to the extant version of swagger-springmvc.
